### PR TITLE
Add inout workaround for GLSL on NVIDIA drivers

### DIFF
--- a/SMAA.hlsl
+++ b/SMAA.hlsl
@@ -643,7 +643,7 @@ void SMAAMovc(bool4 cond, inout float4 variable, float4 value) {
  * Edge Detection Vertex Shader
  */
 void SMAAEdgeDetectionVS(float2 texcoord,
-                         out float4 offset[3]) {
+                         inout float4 offset[3]) {
     offset[0] = mad(SMAA_RT_METRICS.xyxy, float4(-1.0, 0.0, 0.0, -1.0), texcoord.xyxy);
     offset[1] = mad(SMAA_RT_METRICS.xyxy, float4( 1.0, 0.0, 0.0,  1.0), texcoord.xyxy);
     offset[2] = mad(SMAA_RT_METRICS.xyxy, float4(-2.0, 0.0, 0.0, -2.0), texcoord.xyxy);
@@ -654,7 +654,7 @@ void SMAAEdgeDetectionVS(float2 texcoord,
  */
 void SMAABlendingWeightCalculationVS(float2 texcoord,
                                      out float2 pixcoord,
-                                     out float4 offset[3]) {
+                                     inout float4 offset[3]) {
     pixcoord = texcoord * SMAA_RT_METRICS.zw;
 
     // We will use these offsets for the searches later on (see @PSEUDO_GATHER4):


### PR DESCRIPTION
Some NVIDIA GLSL compilers have a discrepancy causing array-typed function arguments declared with the "out" parameter qualifier to not update the caller's input. Whether this is a driver bug or not is debatable, but in any event this workaround should support all cases.

This was reported on the NVIDIA forums a little while ago by someone else: https://devtalk.nvidia.com/default/topic/777925/opengl/varying-array-set-inside-function-using-quot-out-quot-fails/

@xthexder thanks for finding this one!
