### PR TITLE
Support WebGL 1 / OpenGL ES 2

### DIFF
--- a/SMAA.hlsl
+++ b/SMAA.hlsl
@@ -1281,7 +1281,7 @@ float4 SMAANeighborhoodBlendingPS(float2 texcoord,
 
     // Is there any blending weight with a value greater than 0.0?
     SMAA_BRANCH
-    if (dot(a, float4(1.0, 1.0, 1.0, 1.0)) < 1e-5) {
+    if (dot(a, float4(1.0, 1.0, 1.0, 1.0)) <= 1e-5) {
         float4 color = SMAASampleLevelZero(colorTex, texcoord);
 
         #if SMAA_REPROJECTION


### PR DESCRIPTION
This adds support for OpenGL ES 2 and WebGL 1 via `SMAA_GLSL_ES2` as well as support for OpenGL 2 via `SMAA_GLSL_2` (only tested via OpenGL ES - the difference here is that support for `while` loops is not required in ES 2 and is disallowed by WebGL). The output is incorrect when using medium-precision `float` in the fragment shader, so `highp` should be used.
