### PR TITLE
Fix incorrect calculation of local contrast adaption in color edge detection

### DIFF
--- a/SMAA.hlsl
+++ b/SMAA.hlsl
@@ -792,11 +792,11 @@ float2 SMAAColorEdgeDetectionPS(float2 texcoord,
 
     // Calculate left-left and top-top deltas:
     float3 Cleftleft  = SMAASamplePoint(colorTex, offset[2].xy).rgb;
-    t = abs(C - Cleftleft);
+    t = abs(Cleft - Cleftleft);
     delta.z = max(max(t.r, t.g), t.b);
 
     float3 Ctoptop = SMAASamplePoint(colorTex, offset[2].zw).rgb;
-    t = abs(C - Ctoptop);
+    t = abs(Ctop - Ctoptop);
     delta.w = max(max(t.r, t.g), t.b);
 
     // Calculate the final maximum delta:


### PR DESCRIPTION
In SMAAColorEdgeDetectionPS(), the calculations of left-left and top-top deltas are performed as:
```glsl
    t = abs(C - Cleftleft);
```
and
```glsl
    t = abs(C - Ctoptop);
```
However, these are not differences of neighboring pixels, so should be modified as follows:
```glsl
    t = abs(Cleft - Cleftleft);
```
and
```glsl
    t = abs(Ctop - Ctoptop);
```
Thanks!
